### PR TITLE
Fix abs() usage in jet.eta comparison

### DIFF
--- a/Analysis/AnalysisHelpers.py
+++ b/Analysis/AnalysisHelpers.py
@@ -31,7 +31,7 @@ def isGoodMuon(Lepton):
 def isGoodJet(jet):
     if jet.pt() < 25: return False
     if abs(jet.eta()) > 2.5: return False
-    if jet.pt() < 50 and abs(jet.eta() < 2.4) and jet.jvf() < 0.5: return False
+    if jet.pt() < 50 and abs(jet.eta()) < 2.4 and jet.jvf() < 0.5: return False
     return True
 
 # Utility function

--- a/Analysis/AnalysisHelpers.py
+++ b/Analysis/AnalysisHelpers.py
@@ -30,7 +30,7 @@ def isGoodMuon(Lepton):
     
 def isGoodJet(jet):
     if jet.pt() < 25: return False
-    if abs(jet.eta() > 2.5): return False
+    if abs(jet.eta()) > 2.5: return False
     if jet.pt() < 50 and abs(jet.eta() < 2.4) and jet.jvf() < 0.5: return False
     return True
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The provided zip-file should be placed into the Input folder and unzipped via
 ### Analysis
 The files in the root directory of the installation are the various run scripts. Configuration files can be found in the *Configurations* folder. 
 
-As a first test to check whether everything works fine you can simply run a preconfigured analyis via
+As a first test to check whether everything works fine you can simply run a preconfigured analysis via
 
 >     python RunScript.py -a TTbarAnalysis -s "WW, WZ"
 
@@ -30,7 +30,7 @@ The options include:
 >     -p,            --parallel              enables running in parallel (default is single core use)
 >     -n NWORKERS,   --nWorkers NWORKERS     specifies the number of workers if multi core usage is desired (default is 4)
 >     -c CONFIGFILE, --configfile CONFIGFILE specifies the config file to be read (default is Configurations/Configuration.py)
->     -o OUTPUTDIR,  --output OUTPUDIR       specifies the output directory you would like to use instead of the one in the configuration file
+>     -o OUTPUTDIR,  --output OUTPUTDIR      specifies the output directory you would like to use instead of the one in the configuration file
 
 The Configuration.py file specifies how an analysis should behave. The Job portion of the configuration looks like this:
 
@@ -44,7 +44,7 @@ The Configuration.py file specifies how an analysis should behave. The Job porti
 
 The second portion of the configuration file specifies which 
 The locations of the individual files that are to be used for the different 
-processes can be set es such:
+processes can be set as such:
 
 >     Processes = {
 >         # Diboson processes


### PR DESCRIPTION
This PR fixes a logical error where abs() was incorrectly applied to the jet.eta < 2.4 comparison instead of the numeric value of jet.eta(). 
The original code : `if jet.pt() < 50 and abs(jet.eta() < 2.4 ) and jet.jvf() < 0.5: return False`
Fixed code : `if jet.pt() < 50 and abs(jet.eta()) < 2.4 and jet.jvf() < 0.5: return False`